### PR TITLE
Fix an issue that the stream does not start properly on the remote side when the video is turned off

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -528,7 +528,7 @@ exports.rtc = new class {
       if (updateVideo) this._trackLocks.video.unlock();
       if (updateAudio) this._trackLocks.audio.unlock();
     }
-    // For some browsers, audio stream is not played without video stream, 
+    // For some browsers, audio stream is not played without video stream,
     // so add video stream with dummy canvas.
     await this._trackLocks.video.lock();
     if (this._localTracks.stream.getVideoTracks().length === 0) {
@@ -543,19 +543,19 @@ exports.rtc = new class {
   }
 
   createDummyCanvasStream() {
-    if(!this._dummyCanvasStream) {
+    if (!this._dummyCanvasStream) {
       this._dummyCanvas = document.createElement('canvas');
       const canvasWidth = 160;
       const canvasHeight = 120;
       this._dummyCanvas.width = canvasWidth;
       this._dummyCanvas.height = canvasHeight;
       const ctx = this._dummyCanvas.getContext('2d');
-      ctx.fillStyle = "#000000";
+      ctx.fillStyle = '#000000';
       ctx.fillRect(0, 0, canvasWidth, canvasHeight);
       this._dummyCanvasTimerId = setInterval(() => {
-        if(this._dummyCanvas) {
+        if (this._dummyCanvas) {
           const ctx = this._dummyCanvas.getContext('2d');
-          ctx.fillStyle = "#000000";
+          ctx.fillStyle = '#000000';
           ctx.fillRect(0, 0, this._dummyCanvas.width, this._dummyCanvas.height);
         }
       }, 1000);
@@ -565,7 +565,7 @@ exports.rtc = new class {
   }
 
   disposeDummyCanvasStream() {
-    if(this._dummyCanvasTimerId) {
+    if (this._dummyCanvasTimerId) {
       clearInterval(this._dummyCanvasTimerId);
       this._dummyCanvasTimerId = null;
     }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -65,6 +65,7 @@ class LocalTracks extends EventTargetPolyfill {
     super();
     Object.defineProperty(this, 'stream', {value: new MediaStream(), writeable: false});
     this.videoIsScreenshare = false;
+    this.videoIsDummy = false;
   }
 
   getTracks(kind) {
@@ -224,6 +225,10 @@ exports.rtc = new class {
     this._selfViewButtons = {};
     // When grabbing both locks the audio lock must be grabbed first to avoid deadlock.
     this._trackLocks = {audio: new Mutex(), video: new Mutex()};
+    // for dummy canvas stream
+    this._dummyCanvasStream = null;
+    this._dummyCanvas = null;
+    this._dummyCanvasTimerId = null;
   }
 
   get enableDebugLogging() { return enableDebugLogging; }
@@ -448,7 +453,7 @@ exports.rtc = new class {
       if (addAudioTrack) devices.push('mic');
       const addVideoTrack = updateVideo && this._selfViewButtons.video.enabled &&
           (!this._localTracks.stream.getVideoTracks().some((t) => t.readyState === 'live') ||
-           this._localTracks.videoIsScreenshare);
+           this._localTracks.videoIsScreenshare || this._localTracks.videoIsDummy);
       if (addVideoTrack) devices.push('cam');
       const addScreenshareTrack = updateVideo && this._selfViewButtons.screenshare.enabled &&
           !this._selfViewButtons.video.enabled && // Video button overrides screenshare button.
@@ -489,6 +494,9 @@ exports.rtc = new class {
             for (const track of stream.getTracks()) {
               if (track.kind === 'video') {
                 this._localTracks.videoIsScreenshare = devices.includes('screen');
+                this._localTracks.videoIsDummy = false;
+                // dummy video stream is no longer needed
+                this.disposeDummyCanvasStream();
               }
               this._localTracks.setTrack(track.kind, track);
             }
@@ -520,9 +528,47 @@ exports.rtc = new class {
       if (updateVideo) this._trackLocks.video.unlock();
       if (updateAudio) this._trackLocks.audio.unlock();
     }
+    // For some browsers, audio stream is not played without video stream, 
+    // so add video stream with dummy canvas.
+    if (this._localTracks.stream.getVideoTracks().length === 0) {
+      const dummyVideoTrack = this.createDummyCanvasStream().getVideoTracks()[0];
+      this._localTracks.setTrack(dummyVideoTrack.kind, dummyVideoTrack);
+      this._localTracks.videoIsDummy = true;
+    }
     // For most browsers, autoplay with audio is allowed if the user grants access to the camera or
     // microphone, so unmuting auto-muted videos is likely to succeed.
     await this.unmuteAndPlayAll();
+  }
+
+  createDummyCanvasStream() {
+    if(!this._dummyCanvasStream) {
+      this._dummyCanvas = document.createElement('canvas');
+      const canvasWidth = Math.max(160, this._settings.video.constraints?.width?.ideal ?? 0);
+      const canvasHeight = Math.max(120, this._settings.video.constraints?.height?.ideal ?? 0);
+      this._dummyCanvas.width = canvasWidth;
+      this._dummyCanvas.height = canvasHeight;
+      const ctx = this._dummyCanvas.getContext('2d');
+      ctx.fillStyle = "#000000";
+      ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+      this._dummyCanvasTimerId = setInterval(() => {
+        if(this._dummyCanvas) {
+          const ctx = this._dummyCanvas.getContext('2d');
+          ctx.fillStyle = "#000000";
+          ctx.fillRect(0, 0, this._dummyCanvas.width, this._dummyCanvas.height);
+        }
+      }, 1000);
+      this._dummyCanvasStream = this._dummyCanvas.captureStream(1);
+    }
+    return this._dummyCanvasStream;
+  }
+
+  disposeDummyCanvasStream() {
+    if(this._dummyCanvasTimerId) {
+      clearInterval(this._dummyCanvasTimerId);
+      this._dummyCanvasTimerId = null;
+    }
+    this._dummyCanvasStream = null;
+    this._dummyCanvas = null;
   }
 
   async activate() {
@@ -584,6 +630,7 @@ exports.rtc = new class {
       padcookie.setPref('rtcEnabled', false);
       this.hangupAll();
       this.setStream(this.getUserId(), null);
+      this.disposeDummyCanvasStream();
       const $rtcbox = $('#rtcbox');
       $rtcbox.empty(); // In case any peer videos didn't get cleaned up for some reason.
       $rtcbox.hide();
@@ -626,8 +673,8 @@ exports.rtc = new class {
   }
 
   async playVideo($video) {
-    // play() will block indefinitely if there are no enabled tracks.
-    if (!$video[0].srcObject.getTracks().some((t) => t.enabled)) return;
+    // play() will block indefinitely if there are no enabled 'video' tracks.
+    if (!$video[0].srcObject.getVideoTracks().some((t) => t.enabled)) return;
     debug('playing video', $video[0]);
     const $videoContainer = $(`#container_${$video[0].id}`);
     const $playErrorBtn = $videoContainer.find('.play-error-btn');

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -530,11 +530,13 @@ exports.rtc = new class {
     }
     // For some browsers, audio stream is not played without video stream, 
     // so add video stream with dummy canvas.
+    await this._trackLocks.video.lock();
     if (this._localTracks.stream.getVideoTracks().length === 0) {
       const dummyVideoTrack = this.createDummyCanvasStream().getVideoTracks()[0];
       this._localTracks.setTrack(dummyVideoTrack.kind, dummyVideoTrack);
       this._localTracks.videoIsDummy = true;
     }
+    this._trackLocks.video.unlock();
     // For most browsers, autoplay with audio is allowed if the user grants access to the camera or
     // microphone, so unmuting auto-muted videos is likely to succeed.
     await this.unmuteAndPlayAll();
@@ -630,7 +632,6 @@ exports.rtc = new class {
       padcookie.setPref('rtcEnabled', false);
       this.hangupAll();
       this.setStream(this.getUserId(), null);
-      this.disposeDummyCanvasStream();
       const $rtcbox = $('#rtcbox');
       $rtcbox.empty(); // In case any peer videos didn't get cleaned up for some reason.
       $rtcbox.hide();
@@ -640,6 +641,7 @@ exports.rtc = new class {
         for (const track of this._localTracks.stream.getTracks()) {
           this._localTracks.setTrack(track.kind, null);
         }
+        this.disposeDummyCanvasStream();
       } finally {
         this._trackLocks.video.unlock();
         this._trackLocks.audio.unlock();

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -333,7 +333,7 @@ exports.rtc = new class {
   handleClientMessage_RTC_MESSAGE(hookName, {payload: {from, data}}) {
     debug(`(peer ${from}) received message`, data);
     const {publish, clientId, needsReply} = data;
-    if (publish != null && clientId != null) {
+    if (this._activated && publish != null && clientId != null) {
       if (from !== this.getUserId()) {
         debug(`*add cliend id ${clientId} to user id ${from}`);
         this._clientIdToUserId.set(clientId, from);
@@ -545,8 +545,8 @@ exports.rtc = new class {
   createDummyCanvasStream() {
     if(!this._dummyCanvasStream) {
       this._dummyCanvas = document.createElement('canvas');
-      const canvasWidth = Math.max(160, this._settings.video.constraints?.width?.ideal ?? 0);
-      const canvasHeight = Math.max(120, this._settings.video.constraints?.height?.ideal ?? 0);
+      const canvasWidth = 160;
+      const canvasHeight = 120;
       this._dummyCanvas.width = canvasWidth;
       this._dummyCanvas.height = canvasHeight;
       const ctx = this._dummyCanvas.getContext('2d');


### PR DESCRIPTION
Fix an issue that the stream does not start properly on the remote side when the video is turned off.

This pull request introduces support for dummy video streams to address compatibility issues in certain browsers where audio streams require accompanying video streams to play correctly. Key changes include adding logic for creating and disposing of dummy canvas streams, modifying conditions for video track handling, and ensuring proper cleanup of dummy streams.

### Dummy Video Stream Support:

* **Added `videoIsDummy` property to `LocalTracks` class:** This property tracks whether the current video stream is a dummy stream. (`[static/js/index.jsR68](diffhunk://#diff-545ec6b75710fc34567f877877c541f0924c8ddde8f96af69489209ef551eb94R68)`)
* **Introduced dummy canvas stream creation and disposal methods:** Implemented `createDummyCanvasStream` and `disposeDummyCanvasStream` methods to generate and clean up a dummy video stream using a canvas element. (`[[1]](diffhunk://#diff-545ec6b75710fc34567f877877c541f0924c8ddde8f96af69489209ef551eb94R531-R575)`, `[[2]](diffhunk://#diff-545ec6b75710fc34567f877877c541f0924c8ddde8f96af69489209ef551eb94R644)`)
* **Integrated dummy video stream handling in track management:** Updated logic to add a dummy video stream when no live video tracks are present and set `videoIsDummy` accordingly. (`[[1]](diffhunk://#diff-545ec6b75710fc34567f877877c541f0924c8ddde8f96af69489209ef551eb94L451-R456)`, `[[2]](diffhunk://#diff-545ec6b75710fc34567f877877c541f0924c8ddde8f96af69489209ef551eb94R497-R499)`)

### Compatibility Improvements:

* **Modified `playVideo` method:** Updated conditions to specifically check for enabled video tracks, preventing indefinite blocking when no video tracks are active. (`[static/js/index.jsL629-R679](diffhunk://#diff-545ec6b75710fc34567f877877c541f0924c8ddde8f96af69489209ef551eb94L629-R679)`)

### Activation Logic Adjustment:

* **Added `_activated` check in RTC message handling:** Ensured that RTC messages are processed only when the RTC instance is activated. (`[static/js/index.jsL331-R336](diffhunk://#diff-545ec6b75710fc34567f877877c541f0924c8ddde8f96af69489209ef551eb94L331-R336)`)