### PR TITLE
Add conversation audio feature for automatic speaker volume control

### DIFF
--- a/conversationGroupManager.js
+++ b/conversationGroupManager.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const crypto = require('crypto');
+
 const NUM_GROUP_COLORS = 10;
 
 class ConversationGroupManager {
@@ -11,7 +13,7 @@ class ConversationGroupManager {
     this._speakingStates = new Map();
     // userId -> 'conversation'|'standby'
     this._conversationStates = new Map();
-    // groupId -> Set<userId>
+    // groupId (UUID) -> {members: Set<userId>, color: number}
     this._groups = new Map();
     // userId -> groupId (absent = unaffiliated)
     this._userGroupId = new Map();
@@ -19,7 +21,6 @@ class ConversationGroupManager {
     this._excitationTimers = new Map();
     // {timerId, userId} or null (monologue timer: solo speaker -> standby if no response)
     this._monologue = null;
-    this._nextGroupId = 0;
     // Users whose conversation state is held (won't auto-transition to standby).
     this._heldUsers = new Set();
   }
@@ -94,12 +95,29 @@ class ConversationGroupManager {
     this._broadcastState();
   }
 
+  _allocateColor() {
+    const usedColors = new Set(
+        [...this._groups.values()].map((g) => g.color),
+    );
+    for (let i = 0; i < NUM_GROUP_COLORS; i++) {
+      if (!usedColors.has(i)) return i;
+    }
+    return 0;
+  }
+
+  _createGroup(memberIds) {
+    const groupId = crypto.randomUUID();
+    const color = this._allocateColor();
+    this._groups.set(groupId, {members: new Set(memberIds), color});
+    for (const uid of memberIds) {
+      this._userGroupId.set(uid, groupId);
+    }
+    return groupId;
+  }
+
   _formGroupFromMonologue(initiatorId, responderId) {
     this._cancelMonologue();
-    const groupId = this._nextGroupId++;
-    this._groups.set(groupId, new Set([initiatorId, responderId]));
-    this._userGroupId.set(initiatorId, groupId);
-    this._userGroupId.set(responderId, groupId);
+    this._createGroup([initiatorId, responderId]);
     this._conversationStates.set(initiatorId, 'conversation');
     this._conversationStates.set(responderId, 'conversation');
   }
@@ -107,7 +125,7 @@ class ConversationGroupManager {
   _addToGroup(userId, groupId) {
     const group = this._groups.get(groupId);
     if (!group) return;
-    group.add(userId);
+    group.members.add(userId);
     this._userGroupId.set(userId, groupId);
   }
 
@@ -116,8 +134,8 @@ class ConversationGroupManager {
     if (groupId == null) return;
     const group = this._groups.get(groupId);
     if (group) {
-      group.delete(userId);
-      if (group.size === 0) {
+      group.members.delete(userId);
+      if (group.members.size === 0) {
         this._groups.delete(groupId);
       }
     }
@@ -135,10 +153,7 @@ class ConversationGroupManager {
     this._conversationStates.set(speakerId, 'conversation');
     this._conversationStates.set(targetUserId, 'conversation');
 
-    const groupId = this._nextGroupId++;
-    this._groups.set(groupId, new Set([speakerId, targetUserId]));
-    this._userGroupId.set(speakerId, groupId);
-    this._userGroupId.set(targetUserId, groupId);
+    this._createGroup([speakerId, targetUserId]);
 
     // Start excitation timers for users not currently speaking (and not held).
     for (const uid of [speakerId, targetUserId]) {
@@ -222,11 +237,11 @@ class ConversationGroupManager {
 
   _broadcastState() {
     const groups = [];
-    for (const [groupId, members] of this._groups.entries()) {
+    for (const [groupId, group] of this._groups.entries()) {
       groups.push({
         id: groupId,
-        color: groupId % NUM_GROUP_COLORS,
-        members: Array.from(members),
+        color: group.color,
+        members: Array.from(group.members),
       });
     }
     const states = {};

--- a/conversationGroupManager.js
+++ b/conversationGroupManager.js
@@ -1,0 +1,244 @@
+'use strict';
+
+const NUM_GROUP_COLORS = 10;
+
+class ConversationGroupManager {
+  constructor(settings, broadcastFn, logger) {
+    this._settings = settings;
+    this._broadcast = broadcastFn;
+    this._logger = logger;
+    // userId -> boolean
+    this._speakingStates = new Map();
+    // userId -> 'conversation'|'standby'
+    this._conversationStates = new Map();
+    // groupId -> Set<userId>
+    this._groups = new Map();
+    // userId -> groupId (absent = unaffiliated)
+    this._userGroupId = new Map();
+    // userId -> setTimeout ID (excitation timer: speaking stopped -> standby)
+    this._excitationTimers = new Map();
+    // {timerId, userId} or null (monologue timer: solo speaker -> standby if no response)
+    this._monologue = null;
+    this._nextGroupId = 0;
+    // Users whose conversation state is held (won't auto-transition to standby).
+    this._heldUsers = new Set();
+  }
+
+  handleSpeakingStateChange(userId, isSpeaking) {
+    const wasSpeaking = this._speakingStates.get(userId) || false;
+    this._speakingStates.set(userId, isSpeaking);
+    if (isSpeaking && !wasSpeaking) {
+      this._onSpeakingStart(userId);
+    } else if (!isSpeaking && wasSpeaking) {
+      this._onSpeakingStop(userId);
+    }
+  }
+
+  _onSpeakingStart(userId) {
+    this._cancelExcitationTimer(userId);
+    this._conversationStates.set(userId, 'conversation');
+    this._applyGroupFormationRules(userId);
+    this._broadcastState();
+  }
+
+  _onSpeakingStop(userId) {
+    // Held users don't start excitation timer.
+    if (this._heldUsers.has(userId)) return;
+    const excitationTime = this._settings.excitationTime || 15000;
+    const timerId = setTimeout(() => {
+      this._excitationTimers.delete(userId);
+      this._handleExcitationExpired(userId);
+    }, excitationTime);
+    this._excitationTimers.set(userId, timerId);
+  }
+
+  _handleExcitationExpired(userId) {
+    this._conversationStates.set(userId, 'standby');
+    this._removeFromGroup(userId);
+    this._broadcastState();
+  }
+
+  _applyGroupFormationRules(userId) {
+    // If already in a group, stay.
+    if (this._userGroupId.has(userId)) return;
+
+    // If someone is in monologue and a different person speaks, form a group.
+    if (this._monologue && this._monologue.userId !== userId) {
+      this._formGroupFromMonologue(this._monologue.userId, userId);
+      return;
+    }
+
+    if (this._groups.size === 0) {
+      this._startMonologue(userId);
+    } else if (this._groups.size === 1) {
+      // [rule-1] join the only group.
+      const groupId = this._groups.keys().next().value;
+      this._addToGroup(userId, groupId);
+    } else {
+      // Multiple groups: unaffiliated.
+    }
+  }
+
+  _startMonologue(userId) {
+    this._cancelMonologue();
+    const monologueTime = this._settings.monologueTime || 10000;
+    const timerId = setTimeout(() => {
+      this._handleMonologueExpired(userId);
+    }, monologueTime);
+    this._monologue = {timerId, userId};
+  }
+
+  _handleMonologueExpired(userId) {
+    this._monologue = null;
+    this._conversationStates.set(userId, 'standby');
+    this._broadcastState();
+  }
+
+  _formGroupFromMonologue(initiatorId, responderId) {
+    this._cancelMonologue();
+    const groupId = this._nextGroupId++;
+    this._groups.set(groupId, new Set([initiatorId, responderId]));
+    this._userGroupId.set(initiatorId, groupId);
+    this._userGroupId.set(responderId, groupId);
+    this._conversationStates.set(initiatorId, 'conversation');
+    this._conversationStates.set(responderId, 'conversation');
+  }
+
+  _addToGroup(userId, groupId) {
+    const group = this._groups.get(groupId);
+    if (!group) return;
+    group.add(userId);
+    this._userGroupId.set(userId, groupId);
+  }
+
+  _removeFromGroup(userId) {
+    const groupId = this._userGroupId.get(userId);
+    if (groupId == null) return;
+    const group = this._groups.get(groupId);
+    if (group) {
+      group.delete(userId);
+      if (group.size === 0) {
+        this._groups.delete(groupId);
+      }
+    }
+    this._userGroupId.delete(userId);
+  }
+
+  handleDesignation(speakerId, targetUserId) {
+    // Both must not be in conversation state.
+    if (this._conversationStates.get(speakerId) === 'conversation') return;
+    if (this._conversationStates.get(targetUserId) === 'conversation') return;
+
+    this._cancelMonologue();
+    this._cancelExcitationTimer(speakerId);
+    this._cancelExcitationTimer(targetUserId);
+    this._conversationStates.set(speakerId, 'conversation');
+    this._conversationStates.set(targetUserId, 'conversation');
+
+    const groupId = this._nextGroupId++;
+    this._groups.set(groupId, new Set([speakerId, targetUserId]));
+    this._userGroupId.set(speakerId, groupId);
+    this._userGroupId.set(targetUserId, groupId);
+
+    // Start excitation timers for users not currently speaking (and not held).
+    for (const uid of [speakerId, targetUserId]) {
+      if (!this._speakingStates.get(uid) && !this._heldUsers.has(uid)) {
+        const excitationTime = this._settings.excitationTime || 15000;
+        const timerId = setTimeout(() => {
+          this._excitationTimers.delete(uid);
+          this._handleExcitationExpired(uid);
+        }, excitationTime);
+        this._excitationTimers.set(uid, timerId);
+      }
+    }
+    this._broadcastState();
+  }
+
+  setHold(userId, held) {
+    if (held) {
+      this._heldUsers.add(userId);
+      this._cancelExcitationTimer(userId);
+    } else {
+      this._heldUsers.delete(userId);
+      if (!this._speakingStates.get(userId)) {
+        const excitationTime = this._settings.excitationTime || 15000;
+        const timerId = setTimeout(() => {
+          this._excitationTimers.delete(userId);
+          this._handleExcitationExpired(userId);
+        }, excitationTime);
+        this._excitationTimers.set(userId, timerId);
+      }
+    }
+    this._broadcastState();
+  }
+
+  removeUser(userId) {
+    this._cancelExcitationTimer(userId);
+    if (this._monologue && this._monologue.userId === userId) {
+      this._cancelMonologue();
+    }
+    this._heldUsers.delete(userId);
+    this._speakingStates.delete(userId);
+    this._conversationStates.delete(userId);
+    this._removeFromGroup(userId);
+    this._broadcastState();
+  }
+
+  _cancelExcitationTimer(userId) {
+    const timerId = this._excitationTimers.get(userId);
+    if (timerId != null) {
+      clearTimeout(timerId);
+      this._excitationTimers.delete(userId);
+    }
+  }
+
+  _cancelMonologue() {
+    if (this._monologue) {
+      clearTimeout(this._monologue.timerId);
+      this._monologue = null;
+    }
+  }
+
+  get isEmpty() {
+    return this._speakingStates.size === 0 && this._conversationStates.size === 0;
+  }
+
+  destroy() {
+    for (const timerId of this._excitationTimers.values()) {
+      clearTimeout(timerId);
+    }
+    this._excitationTimers.clear();
+    this._cancelMonologue();
+    this._speakingStates.clear();
+    this._conversationStates.clear();
+    this._groups.clear();
+    this._userGroupId.clear();
+    this._heldUsers.clear();
+  }
+
+  broadcastState() {
+    this._broadcastState();
+  }
+
+  _broadcastState() {
+    const groups = [];
+    for (const [groupId, members] of this._groups.entries()) {
+      groups.push({
+        id: groupId,
+        color: groupId % NUM_GROUP_COLORS,
+        members: Array.from(members),
+      });
+    }
+    const states = {};
+    for (const [uid, state] of this._conversationStates.entries()) {
+      states[uid] = state;
+    }
+    const monologue = this._monologue ? {userId: this._monologue.userId} : null;
+    const held = Array.from(this._heldUsers);
+    this._broadcast({
+      conversationState: {groups, states, monologue, held},
+    });
+  }
+}
+
+module.exports = ConversationGroupManager;

--- a/ep.json
+++ b/ep.json
@@ -10,7 +10,8 @@
         "socketio": ":setSocketIO",
         "eejsBlock_mySettings": "",
         "eejsBlock_styles": "",
-        "expressCreateServer" : ""
+        "expressCreateServer" : "",
+        "userLeave": ""
       },
       "client_hooks": {
         "handleClientMessage_RTC_MESSAGE": "ep_webrtc/static/js",

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const sessioninfos = require('ep_etherpad-lite/node/handler/PadMessageHandler').
 const stats = require('ep_etherpad-lite/node/stats');
 const util = require('util');
 const {SignJWT} = require('jose');
+const ConversationGroupManager = require('./conversationGroupManager');
 
 let logger = {};
 for (const level of ['debug', 'info', 'warn', 'error']) {
@@ -58,9 +59,23 @@ const defaultSettings = {
   // The URL to change the spotlight RID.
   // {channelId} will be replaced with the channel ID.
   changeSpotlightRidUrl: null,
+  conversationAudio: {
+    enabled: false,
+    debug: false,
+    suppressedLevel: 0.2,
+    excitationTime: 15000,
+    monologueTime: 10000,
+    unaffiliatedSpeakerLevel: 'suppressed',
+    vad: {
+      speakingThreshold: 10,
+      silenceThreshold: 4,
+      silenceDelay: 1500,
+    },
+  },
 };
 let settings = null;
 let socketio;
+const padGroupManagers = new Map(); // padId -> ConversationGroupManager
 
 // Copied from:
 // https://github.com/ether/etherpad-lite/blob/f95b09e0b6752a0d226d58d8b246831164dc9533/src/node/handler/PadMessageHandler.js#L1411-L1420
@@ -78,6 +93,36 @@ const _getRoomSockets = (padID) => {
       .filter((socket) => socket);
 };
 
+const _broadcastToChannel = (padId, data) => {
+  const msg = {
+    type: 'COLLABROOM',
+    data: {
+      type: 'RTC_MESSAGE',
+      payload: {from: '_server', data},
+    },
+  };
+  for (const sock of _getRoomSockets(padId)) {
+    sock.emit('message', msg);
+  }
+};
+
+const _getOrCreateGroupManager = (padId) => {
+  let mgr = padGroupManagers.get(padId);
+  if (!mgr) {
+    const ca = settings.conversationAudio || {};
+    mgr = new ConversationGroupManager(
+        {
+          excitationTime: ca.excitationTime || 15000,
+          monologueTime: ca.monologueTime || 10000,
+        },
+        (data) => _broadcastToChannel(padId, data),
+        logger,
+    );
+    padGroupManagers.set(padId, mgr);
+  }
+  return mgr;
+};
+
 /**
  * Handles an RTC Message
  * @param socket The socket.io Socket object for the client that sent the message.
@@ -88,6 +133,35 @@ const handleRTCMessage = (socket, payload) => {
   // The handleMessage hook is executed asynchronously, so the user can disconnect between when the
   // message arrives at Etherpad and when this function is called.
   if (userId == null || padId == null) return;
+
+  // Conversation audio group management (only when enabled).
+  const caEnabled = (settings.conversationAudio || {}).enabled;
+  if (caEnabled) {
+    // Intercept speaking state messages for server-side group management.
+    if (payload.data && payload.data.speaking !== undefined) {
+      const mgr = _getOrCreateGroupManager(padId);
+      mgr.handleSpeakingStateChange(userId, payload.data.speaking);
+    }
+
+    // Intercept designation messages.
+    if (payload.data && payload.data.designate) {
+      const mgr = _getOrCreateGroupManager(padId);
+      mgr.handleDesignation(userId, payload.data.designate);
+    }
+
+    // Intercept hold messages.
+    if (payload.data && payload.data.hold !== undefined) {
+      const mgr = _getOrCreateGroupManager(padId);
+      mgr.setHold(userId, payload.data.hold);
+    }
+
+    // Send current state to newly joined client.
+    if (payload.data && payload.data.requestState) {
+      const mgr = padGroupManagers.get(padId);
+      if (mgr) mgr.broadcastState();
+    }
+  }
+
   const msg = {
     type: 'COLLABROOM',
     data: {
@@ -101,10 +175,10 @@ const handleRTCMessage = (socket, payload) => {
   if (payload.to == null) {
     socket.to(padId).emit('message', msg);
   } else {
-    for (const socket of _getRoomSockets(padId)) {
-      const session = sessioninfos[socket.id];
+    for (const sock of _getRoomSockets(padId)) {
+      const session = sessioninfos[sock.id];
       if (session && session.author === payload.to) {
-        socket.emit('message', msg);
+        sock.emit('message', msg);
         break;
       }
     }
@@ -142,6 +216,17 @@ exports.handleMessage = async (hookName, {message, socket}) => {
   if (message.type === 'STATS' && message.data.type === 'RTC_MESSAGE') {
     handleErrorStatMessage(message.data.statName);
     return [null];
+  }
+};
+
+exports.userLeave = async (hookName, {author, padId}) => {
+  if (author == null || padId == null) return;
+  const mgr = padGroupManagers.get(padId);
+  if (!mgr) return;
+  mgr.removeUser(author);
+  if (mgr.isEmpty) {
+    mgr.destroy();
+    padGroupManagers.delete(padId);
   }
 };
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -108,6 +108,44 @@
 }
 #rtcbox .interface-btn.screenshare-btn.off:before { content: "\f109"; }
 
+#rtcbox .designate-btn,
+#rtcbox .hold-btn {
+  position: absolute;
+  top: 20px;
+  right: 4px;
+  border-radius: 3px;
+  padding: 2px 5px;
+  font-size: 9px;
+  font-weight: bold;
+  line-height: 1;
+  cursor: pointer;
+  z-index: 3;
+  background-color: rgba(var(--interface-background-color-rgb, 242, 243, 244),
+                         var(--interface-background-alpha, 0.2));
+  color: rgba(var(--interface-text-color-rgb, 87, 98, 115),
+              var(--interface-text-alpha, 0.6));
+  transition: background-color .2s, color .2s;
+}
+#rtcbox .video-container:hover .designate-btn,
+#rtcbox .video-container:hover .hold-btn {
+  --interface-text-alpha: 0.8;
+  --interface-background-alpha: 0.7;
+}
+#rtcbox .video-container:hover .designate-btn:hover,
+#rtcbox .video-container:hover .hold-btn:hover {
+  --interface-text-alpha: 1.0;
+  --interface-background-alpha: 1.0;
+}
+#rtcbox .designate-btn.disabled {
+  opacity: 0.3;
+  pointer-events: none;
+}
+#rtcbox .hold-btn.held {
+  --interface-text-color-rgb: 255, 255, 255;
+  --interface-background-color-rgb: 76, 175, 80;
+  --interface-background-alpha: 0.8;
+}
+
 #rtcbox .interface-btn.enlarge-btn:before { content: '\e840'; }
 #rtcbox .interface-btn.enlarge-btn.large:before { content: '\e83f'; }
 
@@ -160,6 +198,65 @@
 }
 #rtcbox .video-container.local-user {
   order: -1; /* first position */
+}
+#rtcbox .video-container.speaking {
+  outline: 2px solid #4CAF50;
+  outline-offset: -2px;
+}
+#rtcbox .state-indicator {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: #9E9E9E;
+  z-index: 3;
+}
+#rtcbox .state-indicator[data-group-color="0"] { background-color: #4CAF50; }
+#rtcbox .state-indicator[data-group-color="1"] { background-color: #2196F3; }
+#rtcbox .state-indicator[data-group-color="2"] { background-color: #FF5722; }
+#rtcbox .state-indicator[data-group-color="3"] { background-color: #9C27B0; }
+#rtcbox .state-indicator[data-group-color="4"] { background-color: #FF9800; }
+#rtcbox .state-indicator[data-group-color="5"] { background-color: #00BCD4; }
+#rtcbox .state-indicator[data-group-color="6"] { background-color: #E91E63; }
+#rtcbox .state-indicator[data-group-color="7"] { background-color: #8BC34A; }
+#rtcbox .state-indicator[data-group-color="8"] { background-color: #3F51B5; }
+#rtcbox .state-indicator[data-group-color="9"] { background-color: #795548; }
+#rtcbox .state-indicator.monologue {
+  background-color: #FFC107;
+  animation: monologue-pulse 1s ease-in-out infinite;
+}
+@keyframes monologue-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+#rtcbox .vad-level-meter {
+  position: absolute;
+  bottom: 40px;
+  left: 5px;
+  right: 5px;
+  height: 12px;
+  background-color: rgba(0, 0, 0, 0.4);
+  border-radius: 3px;
+  overflow: hidden;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+}
+#rtcbox .vad-level-bar {
+  height: 100%;
+  width: 0;
+  background-color: #ff9800;
+  border-radius: 3px;
+  transition: width 0.05s linear;
+}
+#rtcbox .vad-level-value {
+  position: absolute;
+  right: 4px;
+  font-size: 9px;
+  color: white;
+  line-height: 12px;
 }
 
 @media (max-width: 800px) {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -109,7 +109,8 @@
 #rtcbox .interface-btn.screenshare-btn.off:before { content: "\f109"; }
 
 #rtcbox .designate-btn,
-#rtcbox .hold-btn {
+#rtcbox .hold-btn,
+#rtcbox .beep-btn {
   position: absolute;
   top: 20px;
   right: 4px;
@@ -127,12 +128,14 @@
   transition: background-color .2s, color .2s;
 }
 #rtcbox .video-container:hover .designate-btn,
-#rtcbox .video-container:hover .hold-btn {
+#rtcbox .video-container:hover .hold-btn,
+#rtcbox .video-container:hover .beep-btn {
   --interface-text-alpha: 0.8;
   --interface-background-alpha: 0.7;
 }
 #rtcbox .video-container:hover .designate-btn:hover,
-#rtcbox .video-container:hover .hold-btn:hover {
+#rtcbox .video-container:hover .hold-btn:hover,
+#rtcbox .video-container:hover .beep-btn:hover {
   --interface-text-alpha: 1.0;
   --interface-background-alpha: 1.0;
 }
@@ -143,6 +146,14 @@
 #rtcbox .hold-btn.held {
   --interface-text-color-rgb: 255, 255, 255;
   --interface-background-color-rgb: 76, 175, 80;
+  --interface-background-alpha: 0.8;
+}
+#rtcbox .beep-btn {
+  top: 36px;
+}
+#rtcbox .beep-btn.beeping {
+  --interface-text-color-rgb: 255, 255, 255;
+  --interface-background-color-rgb: 233, 30, 99;
   --interface-background-alpha: 0.8;
 }
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1103,6 +1103,47 @@ exports.rtc = new class {
     }
 
     // /////
+    // Beep button (debug mode, local panel only) — injects dummy tone into VAD
+    // /////
+
+    const caDebug = (this._settings.conversationAudio || {}).debug;
+    if (caDebug && isLocal) {
+      const $beepBtn = $('<span>')
+          .addClass('beep-btn')
+          .text('BEEP')
+          .attr('title', 'Inject dummy audio into VAD')
+          .appendTo($videoContainer);
+      this._selfViewButtons.beep = {
+        get enabled() { return $beepBtn.hasClass('beeping'); },
+        set enabled(val) {
+          $beepBtn.toggleClass('beeping', val);
+        },
+      };
+      this._selfViewButtons.beep.enabled = false;
+      addAsyncEventHandlers($beepBtn, {
+        click: async () => {
+          const newBeeping = !this._selfViewButtons.beep.enabled;
+          this._selfViewButtons.beep.enabled = newBeeping;
+          if (!this._vad) return;
+          if (newBeeping) {
+            this._vad.startDummyTone();
+            const mixed = this._vad.mixedStream;
+            const mixedTrack = mixed && mixed.getAudioTracks()[0];
+            if (mixedTrack && this._soraClient) {
+              this._soraClient.replaceLocalTrack(mixedTrack);
+            }
+          } else {
+            this._vad.stopDummyTone();
+            const micTrack = this._localTracks.stream.getAudioTracks()[0];
+            if (micTrack && this._soraClient) {
+              this._soraClient.replaceLocalTrack(micTrack);
+            }
+          }
+        },
+      });
+    }
+
+    // /////
     // Video and Screen Sharing Buttons
     // /////
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -16,6 +16,7 @@
 'use strict';
 
 const SoraClient = require('./soraClient');
+const VoiceActivityDetector = require('./voiceActivityDetector');
 require('./adapter');
 const padcookie = require('ep_etherpad-lite/static/js/pad_cookie').padcookie;
 
@@ -207,6 +208,11 @@ exports.rtc = new class {
         this._soraClient.replaceLocalTrack(newTrack);
       }
 
+      // Update VAD when audio track changes.
+      if (this._vad && kind === 'audio') {
+        this._vad.setStream(this._localTracks.stream);
+      }
+
       // Update the audio/video buttons to reflect the new state.
       if (newTrack != null) return;
       switch (oldTrack.kind) {
@@ -229,6 +235,15 @@ exports.rtc = new class {
     this._dummyCanvasStream = null;
     this._dummyCanvas = null;
     this._dummyCanvasTimerId = null;
+    // VAD and speaking state
+    this._vad = null;
+    this._isSpeaking = false;
+    this._peerSpeakingState = new Map(); // userId -> boolean
+    // Conversation group state (received from server)
+    this._conversationGroups = []; // Array<Array<userId>>
+    this._conversationStates = {}; // userId -> 'conversation'|'standby'
+    this._monologue = null; // {userId, active} or null
+    this._heldUsers = []; // Array<userId>
   }
 
   get enableDebugLogging() { return enableDebugLogging; }
@@ -349,6 +364,14 @@ exports.rtc = new class {
           this.updateSpotlightRids();
         }
       }
+    } else if (this._activated && from === '_server' && data.conversationState) {
+      this._handleConversationStateUpdate(data.conversationState);
+    } else if (this._activated && from !== this.getUserId() && data.speaking !== undefined) {
+      this._peerSpeakingState.set(from, data.speaking);
+      if ((this._settings.conversationAudio || {}).debug) {
+        this._updateSpeakingIndicator(from, data.speaking);
+      }
+      this._updateAllPeerVolumes();
     } else if (this._activated && from !== this.getUserId() &&
           (this._peers.has(from) || data.hangup == null)) {
       this.getPeerConnection(from).receiveMessage(data);
@@ -357,6 +380,107 @@ exports.rtc = new class {
   }
 
   // END OF API HOOKS
+
+  _updateSpeakingIndicator(userId, isSpeaking) {
+    $(`#container_${getVideoId(userId)}`).toggleClass('speaking', isSpeaking);
+  }
+
+  _updateLevelMeter(rms) {
+    const $meter = $(`#container_${getVideoId(this.getUserId())} .vad-level-meter`);
+    if ($meter.length === 0) return;
+    const ca = this._settings.conversationAudio || {};
+    const threshold = (ca.vad || {}).speakingThreshold || 10;
+    // Clamp rms to 0-50 range for display.
+    const pct = Math.min(rms / 50 * 100, 100);
+    $meter.find('.vad-level-bar').css('width', `${pct}%`);
+    $meter.find('.vad-level-value').text(`RMS: ${rms.toFixed(1)}`);
+    $meter.find('.vad-level-bar').css(
+        'background-color', rms > threshold ? '#4CAF50' : '#ff9800'
+    );
+  }
+
+  _handleConversationStateUpdate(state) {
+    this._conversationGroups = state.groups || [];
+    this._conversationStates = state.states || {};
+    this._monologue = state.monologue || null;
+    this._heldUsers = state.held || [];
+    debug('conversation state update:', state);
+    this._updateAllPeerVolumes();
+    this._updateGroupIndicators();
+  }
+
+  _updateAllPeerVolumes() {
+    if (!(this._settings.conversationAudio || {}).enabled) return;
+    for (const userId of this._peers.keys()) {
+      this._updatePeerVolume(userId);
+    }
+  }
+
+  _findGroupForUser(userId) {
+    for (const group of this._conversationGroups) {
+      if (group.members.indexOf(userId) >= 0) return group;
+    }
+    return null;
+  }
+
+  _updatePeerVolume(userId) {
+    const ca = this._settings.conversationAudio || {};
+    if (!ca.enabled) return;
+    const $video = $(`#${getVideoId(userId)}`);
+    if ($video.length === 0 || $video[0].muted) return;
+    const suppressedLevel = ca.suppressedLevel != null ? ca.suppressedLevel : 0.2;
+
+    // Before receiving group state from server, use speaking state directly.
+    if (Object.keys(this._conversationStates).length === 0) {
+      const isSpeaking = this._peerSpeakingState.get(userId) || false;
+      $video[0].volume = isSpeaking ? 1.0 : suppressedLevel;
+      return;
+    }
+
+    const myState = this._conversationStates[this.getUserId()] || 'standby';
+
+    // Monologue: speaker is heard by everyone at standard level.
+    if (this._monologue && this._monologue.userId === userId) {
+      $video[0].volume = 1.0;
+      return;
+    }
+
+    let volume;
+    if (myState === 'standby') {
+      volume = suppressedLevel;
+    } else {
+      const myGroup = this._findGroupForUser(this.getUserId());
+      const peerGroup = this._findGroupForUser(userId);
+      if (myGroup && peerGroup && myGroup.id === peerGroup.id) {
+        volume = 1.0;
+      } else if (!peerGroup) {
+        volume = ca.unaffiliatedSpeakerLevel === 'standard' ? 1.0 : suppressedLevel;
+      } else {
+        volume = suppressedLevel;
+      }
+    }
+    $video[0].volume = volume;
+  }
+
+  _updateGroupIndicators() {
+    const myId = this.getUserId();
+    const myState = this._conversationStates[myId] || 'standby';
+    const allUserIds = [myId, ...this._peers.keys()];
+    for (const userId of allUserIds) {
+      const $container = $(`#container_${getVideoId(userId)}`);
+      if ($container.length === 0) continue;
+      const $indicator = $container.find('.state-indicator');
+      const isMonologue = this._monologue && this._monologue.userId === userId;
+      $indicator.toggleClass('monologue', !!isMonologue);
+      const group = this._findGroupForUser(userId);
+      // Group color on indicator; absent = gray (CSS default).
+      $indicator.attr('data-group-color', group && !isMonologue ? group.color : '');
+      // Disable TALK button when either party is in conversation.
+      const peerState = this._conversationStates[userId] || 'standby';
+      const canDesignate = myState !== 'conversation' && peerState !== 'conversation';
+      $container.find('.designate-btn').toggleClass('disabled', !canDesignate);
+    }
+  }
 
   updatePeerNameAndColor(userInfo) {
     if (!userInfo) return;
@@ -634,6 +758,24 @@ exports.rtc = new class {
             updateAudio: this._settings.audio.disabled !== 'hard',
             updateVideo: this._settings.video.disabled !== 'hard',
           });
+          // Initialize VAD for speaking detection (only when conversationAudio is enabled).
+          const ca = this._settings.conversationAudio || {};
+          if (ca.enabled) {
+            const vadSettings = ca.vad || {};
+            this._vad = new VoiceActivityDetector(vadSettings);
+            this._vad.addEventListener('speakingstatechanged', ({isSpeaking}) => {
+              this._isSpeaking = isSpeaking;
+              debug(`speaking state changed: ${isSpeaking}`);
+              this.sendMessage(null, {speaking: isSpeaking});
+              if (ca.debug) this._updateSpeakingIndicator(this.getUserId(), isSpeaking);
+            });
+            if (ca.debug) {
+              this._vad.addEventListener('level', ({rms}) => {
+                this._updateLevelMeter(rms);
+              });
+            }
+            this._vad.setStream(this._localTracks.stream);
+          }
           // initialize sora client
           this._soraClient = new SoraClient(
               this._settings.signalingUrls,
@@ -659,6 +801,7 @@ exports.rtc = new class {
         } finally {
           $checkbox.prop('disabled', false);
         }
+        this.sendMessage(null, {requestState: true});
         debug('activated');
       })();
     }
@@ -677,6 +820,16 @@ exports.rtc = new class {
     try {
       this._activated = null;
       padcookie.setPref('rtcEnabled', false);
+      if (this._vad) {
+        this._vad.destroy();
+        this._vad = null;
+      }
+      this._isSpeaking = false;
+      this._peerSpeakingState.clear();
+      this._conversationGroups = [];
+      this._conversationStates = {};
+      this._monologue = null;
+      this._heldUsers = [];
       this.hangupAll();
       this.setStream(this.getUserId(), null);
       const $rtcbox = $('#rtcbox');
@@ -711,6 +864,7 @@ exports.rtc = new class {
   async setStream(userId, stream) {
     let $video = $(`#${getVideoId(userId)}`);
     if (!stream) {
+      this._peerSpeakingState.delete(userId);
       $(`#container_${getVideoId(userId)}`).remove();
       return;
     }
@@ -718,6 +872,7 @@ exports.rtc = new class {
     if ($video.length === 0) $video = this.addInterface(userId, isLocal);
     // Avoid flicker by checking if .srcObject already equals stream.
     if ($video[0].srcObject !== stream) $video[0].srcObject = stream;
+    if (!isLocal) this._updatePeerVolume(userId);
     await this.playVideo($video);
   }
 
@@ -801,7 +956,13 @@ exports.rtc = new class {
         .css({width: '0', height: '0'})
         .append($name)
         .append($video)
+        .append(!(this._settings.conversationAudio || {}).enabled ? null
+        : $('<div>').addClass('state-indicator'))
         .append($interface)
+        .append(!isLocal || !(this._settings.conversationAudio || {}).debug ? null
+        : $('<div>').addClass('vad-level-meter')
+            .append($('<div>').addClass('vad-level-bar'))
+            .append($('<span>').addClass('vad-level-value')))
         // `min-width: min-content` and `min-height: min-content` don't work on all browsers. Even
         // if they did, the peer name display has `position: absolute` so that a really long name
         // doesn't cause $videoContainer to become overly wide. This function sets `min-width` and
@@ -822,6 +983,7 @@ exports.rtc = new class {
     if (isLocal) $videoContainer.prependTo($('#rtcbox'));
     else $videoContainer.appendTo($('#rtcbox'));
     this.updatePeerNameAndColor(this.getUserFromId(userId));
+    this._updateGroupIndicators();
 
     // For tests it is important to know when an asynchronous event handler has finishing handling
     // an event. This function wraps async event handler functions so that tests can wait for all
@@ -874,8 +1036,12 @@ exports.rtc = new class {
         const muted = audioInterface.enabled;
         _debug(`audio button clicked to ${muted ? 'dis' : 'en'}able audio`);
         audioInterface.enabled = !muted;
-        if (isLocal) await this.updateLocalTracks({updateAudio: true});
-        else $video[0].muted = muted;
+        if (isLocal) {
+          await this.updateLocalTracks({updateAudio: true});
+        } else {
+          $video[0].muted = muted;
+          if (!$video[0].muted) this._updatePeerVolume(userId);
+        }
         // Do not use `await` when calling unmuteAndPlayAll() because unmuting is best-effort
         // (success of this handler does not depend on the ability to unmute, and this handler's
         // idle/busy status should not be affected by unmuteAndPlayAll()). Call unmuteAndPlayAll()
@@ -884,6 +1050,57 @@ exports.rtc = new class {
         this.unmuteAndPlayAll();
       },
     });
+
+    // /////
+    // Designate button (remote panels only)
+    // /////
+
+    const caEnabled = (this._settings.conversationAudio || {}).enabled;
+
+    if (caEnabled && !isLocal) {
+      const $designateBtn = $('<span>')
+          .addClass('designate-btn')
+          .text('TALK')
+          .attr('title', 'Talk to this person')
+          .appendTo($videoContainer);
+      addAsyncEventHandlers($designateBtn, {
+        click: async () => {
+          const peerState = this._conversationStates[userId];
+          if (peerState === 'conversation') return;
+          const myState = this._conversationStates[this.getUserId()];
+          if (myState === 'conversation') return;
+          this.sendMessage(null, {designate: userId});
+        },
+      });
+    }
+
+    // /////
+    // Hold button (local panel only)
+    // /////
+
+    if (caEnabled && isLocal) {
+      const $holdBtn = $('<span>')
+          .addClass('hold-btn')
+          .text('HOLD')
+          .attr('title', 'Hold conversation state')
+          .appendTo($videoContainer);
+      this._selfViewButtons.hold = {
+        get enabled() { return $holdBtn.hasClass('held'); },
+        set enabled(val) {
+          $holdBtn
+              .toggleClass('held', val)
+              .attr('title', val ? 'Release hold' : 'Hold conversation state');
+        },
+      };
+      this._selfViewButtons.hold.enabled = false;
+      addAsyncEventHandlers($holdBtn, {
+        click: async () => {
+          const newHeld = !this._selfViewButtons.hold.enabled;
+          this._selfViewButtons.hold.enabled = newHeld;
+          this.sendMessage(null, {hold: newHeld});
+        },
+      });
+    }
 
     // /////
     // Video and Screen Sharing Buttons

--- a/static/js/voiceActivityDetector.js
+++ b/static/js/voiceActivityDetector.js
@@ -35,6 +35,8 @@ class VoiceActivityDetector extends EventTargetPolyfill {
     this._dataArray = new Uint8Array(this._analyser.fftSize);
     this._source = this._audioContext.createMediaStreamSource(stream);
     this._source.connect(this._analyser);
+    this._destination = this._audioContext.createMediaStreamDestination();
+    this._source.connect(this._destination);
     this._startAnalysis();
   }
 
@@ -51,6 +53,7 @@ class VoiceActivityDetector extends EventTargetPolyfill {
       this._analyser.disconnect();
       this._analyser = null;
     }
+    this._destination = null;
     this._dataArray = null;
   }
 
@@ -96,7 +99,37 @@ class VoiceActivityDetector extends EventTargetPolyfill {
     }
   }
 
+  get mixedStream() {
+    return this._destination ? this._destination.stream : null;
+  }
+
+  startDummyTone() {
+    if (!this._audioContext || !this._analyser || !this._destination) return;
+    this.stopDummyTone();
+    this._dummyOscillator = this._audioContext.createOscillator();
+    this._dummyGain = this._audioContext.createGain();
+    this._dummyOscillator.frequency.value = 440;
+    this._dummyGain.gain.value = 0.5;
+    this._dummyOscillator.connect(this._dummyGain);
+    this._dummyGain.connect(this._analyser);
+    this._dummyGain.connect(this._destination);
+    this._dummyOscillator.start();
+  }
+
+  stopDummyTone() {
+    if (this._dummyOscillator) {
+      this._dummyOscillator.stop();
+      this._dummyOscillator.disconnect();
+      this._dummyOscillator = null;
+    }
+    if (this._dummyGain) {
+      this._dummyGain.disconnect();
+      this._dummyGain = null;
+    }
+  }
+
   destroy() {
+    this.stopDummyTone();
     this._disconnect();
     if (this._audioContext && this._audioContext.state !== 'closed') {
       this._audioContext.close();

--- a/static/js/voiceActivityDetector.js
+++ b/static/js/voiceActivityDetector.js
@@ -1,0 +1,110 @@
+'use strict';
+
+const EventTargetPolyfill = require('./eventTargetPolyfill');
+
+class VoiceActivityDetector extends EventTargetPolyfill {
+  constructor(options = {}) {
+    super();
+    this._speakingThreshold = options.speakingThreshold || 10;
+    this._silenceThreshold = options.silenceThreshold || 4;
+    this._silenceDelay = options.silenceDelay || 1500;
+    this._isSpeaking = false;
+    this._silenceStartTime = null;
+    this._audioContext = null;
+    this._analyser = null;
+    this._source = null;
+    this._dataArray = null;
+    this._rafId = null;
+  }
+
+  get isSpeaking() {
+    return this._isSpeaking;
+  }
+
+  setStream(stream) {
+    this._disconnect();
+    if (!stream || stream.getAudioTracks().length === 0) return;
+    if (!this._audioContext || this._audioContext.state === 'closed') {
+      this._audioContext = new AudioContext();
+    }
+    if (this._audioContext.state === 'suspended') {
+      this._audioContext.resume();
+    }
+    this._analyser = this._audioContext.createAnalyser();
+    this._analyser.fftSize = 256;
+    this._dataArray = new Uint8Array(this._analyser.fftSize);
+    this._source = this._audioContext.createMediaStreamSource(stream);
+    this._source.connect(this._analyser);
+    this._startAnalysis();
+  }
+
+  _disconnect() {
+    if (this._rafId != null) {
+      cancelAnimationFrame(this._rafId);
+      this._rafId = null;
+    }
+    if (this._source) {
+      this._source.disconnect();
+      this._source = null;
+    }
+    if (this._analyser) {
+      this._analyser.disconnect();
+      this._analyser = null;
+    }
+    this._dataArray = null;
+  }
+
+  _startAnalysis() {
+    const analyze = () => {
+      this._rafId = requestAnimationFrame(analyze);
+      if (!this._analyser || !this._dataArray) return;
+      this._analyser.getByteTimeDomainData(this._dataArray);
+      // Compute RMS amplitude (deviation from 128 center).
+      let sumSquares = 0;
+      for (let i = 0; i < this._dataArray.length; i++) {
+        const deviation = this._dataArray[i] - 128;
+        sumSquares += deviation * deviation;
+      }
+      const rms = Math.sqrt(sumSquares / this._dataArray.length);
+      this.dispatchEvent(Object.assign(new CustomEvent('level'), {rms}));
+      this._processLevel(rms);
+    };
+    this._rafId = requestAnimationFrame(analyze);
+  }
+
+  _processLevel(rms) {
+    if (!this._isSpeaking) {
+      if (rms > this._speakingThreshold) {
+        this._isSpeaking = true;
+        this._silenceStartTime = null;
+        this.dispatchEvent(
+            Object.assign(new CustomEvent('speakingstatechanged'), {isSpeaking: true})
+        );
+      }
+    } else if (rms < this._silenceThreshold) {
+      if (this._silenceStartTime == null) {
+        this._silenceStartTime = performance.now();
+      } else if (performance.now() - this._silenceStartTime >= this._silenceDelay) {
+        this._isSpeaking = false;
+        this._silenceStartTime = null;
+        this.dispatchEvent(
+            Object.assign(new CustomEvent('speakingstatechanged'), {isSpeaking: false})
+        );
+      }
+    } else {
+      this._silenceStartTime = null;
+    }
+  }
+
+  destroy() {
+    this._disconnect();
+    if (this._audioContext && this._audioContext.state !== 'closed') {
+      this._audioContext.close();
+    }
+    this._audioContext = null;
+    this._isSpeaking = false;
+    this._silenceStartTime = null;
+  }
+}
+
+module.exports = VoiceActivityDetector;


### PR DESCRIPTION
 ## Summary  
 - Add conversation audio feature that automatically adjusts peer volume based on who is speaking and conversation group membership                   
  - Server-side ConversationGroupManager handles group creation/merge/dissolution, monologue detection, and excitation timers
  - Client-side per-peer volume control                                                           
  - Add debug tools: BEEP button (dummy tone injection), VAD RMS meter, speaking/group indicators                