### PR TITLE
fix: ghost peer panel left after Safari back navigation

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1169,8 +1169,8 @@ exports.rtc = new class {
     this.setStream(userId, null);
     const peer = this._peers.get(userId);
     if (peer == null) return;
-    peer.close();
     this._peers.delete(userId);
+    peer.close();
   }
 
   // 自分の情報(userId, sora client id)を公開する
@@ -1206,6 +1206,7 @@ exports.rtc = new class {
       });
       peer.addEventListener('streamgone', async ({stream}) => {
         _debug(`remote stream ${stream.id} removed`);
+        if (!this._peers.has(userId)) return;
         const $videoContainer = $(`#container_${getVideoId(userId)}`);
         $videoContainer.find('.disconnected-error-btn').css({display: ''});
         // The userLeave hook isn't called until it has been 8s since the peer left. Wait a bit


### PR DESCRIPTION
## Background

  When a remote peer leaves a Safari tab via back navigation, the bfcache prevents `beforeunload` / `unload` from firing, so the hangup message is never sent to other peers. On the remaining peer side, `userLeave` fires first, triggering `hangup()` which removes the DOM container. `peer.close()` then synchronously fires `streamgone`, whose listener recreates the video container with an empty `MediaStream`, leaving an orphan "ghost" panel.

## Changes

  In `static/js/index.js`:

  1. In `hangup()`, move `this._peers.delete(userId)` before `peer.close()` so that by the time `streamgone` fires synchronously, `_peers.has(userId)` is already `false`.
  2. Add an early-return guard at the top of the `streamgone` listener: `if (!this._peers.has(userId)) return;`. This prevents DOM recreation when the peer has already been torn down.