### PR TITLE
Replace silent early returns with warn()/throw for debuggability

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -22,6 +22,7 @@ const padcookie = require('ep_etherpad-lite/static/js/pad_cookie').padcookie;
 
 let enableDebugLogging = false;
 const debug = (...args) => { if (enableDebugLogging) console.debug('ep_webrtc:', ...args); };
+const warn = (...args) => console.warn('ep_webrtc:', ...args);
 
 const EventTargetPolyfill = require('./eventTargetPolyfill');
 
@@ -336,7 +337,11 @@ exports.rtc = new class {
   userJoinOrUpdate(hookName, {userInfo}) {
     const {userId} = userInfo;
     debug(`(peer ${userId}) join or update`);
-    if (!this._activated || !userId) return;
+    if (!this._activated) return;
+    if (!userId) {
+      warn('userJoinOrUpdate: userId is missing from userInfo');
+      return;
+    }
     this.updatePeerNameAndColor(userInfo);
   }
 
@@ -525,7 +530,7 @@ exports.rtc = new class {
           .then((res) => {
             if (!res.ok) {
               // retry after timeout * 2 milliseconds later
-              console.warn(
+              warn(
                   `Failed to change spotlight rid: ${res.status} ${res.statusText},` +
                   ` will retry after ${timeout * 2}ms`
               );
@@ -761,7 +766,7 @@ exports.rtc = new class {
           // Initialize VAD for speaking detection (only when conversationAudio is enabled).
           const ca = this._settings.conversationAudio || {};
           if (ca.enabled) {
-            const vadSettings = ca.vad || {};
+            const vadSettings = {...(ca.vad || {}), warn};
             this._vad = new VoiceActivityDetector(vadSettings);
             this._vad.addEventListener('speakingstatechanged', ({isSpeaking}) => {
               this._isSpeaking = isSpeaking;
@@ -853,7 +858,10 @@ exports.rtc = new class {
   }
 
   getUserFromId(userId) {
-    if (!this._pad || !this._pad.collabClient) return null;
+    if (!this._pad || !this._pad.collabClient) {
+      warn('getUserFromId: _pad or collabClient is not initialized');
+      return null;
+    }
     const result = this._pad.collabClient
         .getConnectedUsers()
         .filter((user) => user.userId === userId);
@@ -1124,7 +1132,10 @@ exports.rtc = new class {
         click: async () => {
           const newBeeping = !this._selfViewButtons.beep.enabled;
           this._selfViewButtons.beep.enabled = newBeeping;
-          if (!this._vad) return;
+          if (!this._vad) {
+            warn('beep click: _vad is not initialized');
+            return;
+          }
           if (newBeeping) {
             this._vad.startDummyTone();
             const mixed = this._vad.mixedStream;

--- a/static/js/voiceActivityDetector.js
+++ b/static/js/voiceActivityDetector.js
@@ -5,6 +5,7 @@ const EventTargetPolyfill = require('./eventTargetPolyfill');
 class VoiceActivityDetector extends EventTargetPolyfill {
   constructor(options = {}) {
     super();
+    this._warn = options.warn || (() => {});
     this._speakingThreshold = options.speakingThreshold || 10;
     this._silenceThreshold = options.silenceThreshold || 4;
     this._silenceDelay = options.silenceDelay || 1500;
@@ -60,7 +61,10 @@ class VoiceActivityDetector extends EventTargetPolyfill {
   _startAnalysis() {
     const analyze = () => {
       this._rafId = requestAnimationFrame(analyze);
-      if (!this._analyser || !this._dataArray) return;
+      if (!this._analyser || !this._dataArray) {
+        this._warn('_startAnalysis: _analyser or _dataArray is null during analysis loop');
+        return;
+      }
       this._analyser.getByteTimeDomainData(this._dataArray);
       // Compute RMS amplitude (deviation from 128 center).
       let sumSquares = 0;
@@ -104,7 +108,10 @@ class VoiceActivityDetector extends EventTargetPolyfill {
   }
 
   startDummyTone() {
-    if (!this._audioContext || !this._analyser || !this._destination) return;
+    if (!this._audioContext || !this._analyser || !this._destination) {
+      throw new Error(
+          'startDummyTone: called before setStream() — audio nodes not initialized');
+    }
     this.stopDummyTone();
     this._dummyOscillator = this._audioContext.createOscillator();
     this._dummyGain = this._audioContext.createGain();


### PR DESCRIPTION
## Summary

Replaces silent early returns at "should-not-happen" branches in `index.js` and `voiceActivityDetector.js` with `console.warn()` (for tolerable-but-unexpected states) or `throw` (for caller contract violations).
  
Silent returns make production bugs invisible — the only signal is "the feature didn't work." Surfacing these branches gives us a console trail when they actually fire.
  
Normal lifecycle guards (e.g. `!_activated`) are left silent.